### PR TITLE
Update readme.md to use npm for installation guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,12 +8,8 @@ The CLI operates from the export of your blog's settings and data. Any changes m
 
 # Installation
 
-The CLI uses [Node.js](http://nodejs.org/) so make sure you have it installed and perform the following to get the CLI up and running:
-
 ```bash
-git clone git@github.com:jeffdonthemic/ghost-cli.git
-cd ghost-cli
-npm install
+npm install ghost-cli
 ```
 
 Rename `config-sample.js` to `config.js` and add your blog's domain (e.g., http://blog.jeffdouglas.com) and Cloudinary Account Details from the [Cloudinary Dashboard](https://cloudinary.com/console) if you want to use the Cloudinary functions. 


### PR DESCRIPTION
The proper way to install a package for Ghost would be with npm. A git clone _would work_, but using npm is the standard. See issue #1.
