### PR TITLE
Updated JSON structure to be compatible with ghost >= 0.5.2

### DIFF
--- a/bin/ghost
+++ b/bin/ghost
@@ -12,7 +12,7 @@ cloudinary.config({
 });  
 
 program
-  .version('0.0.3')
+  .version('0.0.4')
 
 program
   .command('blogstats')
@@ -85,11 +85,18 @@ program
 });     
 
 program
-  .command('waybackit')
-  .description('Looks for an image in a file and tries to locate it in the wayback machine.')
+  .command('cloudit')
+  .description('Upload all non cloudinary images in posts.')
   .action(function(file){
-    spooky.waybackit(file);
-});     
+    spooky.cloudit(file);
+}); 
+
+program
+  .command('checkcloud')
+  .description('Check posts with local images.')
+  .action(function(){
+    spooky.checkcloud();
+});      
 
 program
   .command('dump')
@@ -97,5 +104,6 @@ program
   .action(function(){
     spooky.dump(); 
 });    
+
 
 program.parse(process.argv);

--- a/config-sample.js
+++ b/config-sample.js
@@ -3,6 +3,7 @@ var config = {
   blog_domain: "YOUR-BLOG-URL",
   pagesDir: [__dirname,'pages'].join('/'),
   imagesDir: [__dirname,'images'].join('/'),
+  localImagePath: "(/content/images/",
   cloudinary : {
     cloud_name: 'YOUR-CLOUDINARY-CLOUD-NAME',
     api_key: 'YOUR-CLOUDINARY-API-KEY', 

--- a/lib/spooky.js
+++ b/lib/spooky.js
@@ -307,7 +307,7 @@ exports.checkcloud = function() {
     function findImageInFile(file) {
       var deferred = Q.defer();
       fs.readFile(file, function (err,data) {
-        var targetUrl = '(/content/images/';
+        var targetUrl = config.localImagePath;
         if (err) { if (err) deferred.reject(err); }
         if (!err) {
           var md = data.toString();
@@ -357,7 +357,7 @@ exports.cloudit = function(file) {
   function findImageInFile(file) {
       var deferred = Q.defer();
       fs.readFile(file, function (err,data) {
-        var targetUrl = '(/content/images/';
+        var targetUrl = config.localImagePath;
         if (err) { if (err) deferred.reject(err); }
         if (!err) {
           var md = data.toString();

--- a/lib/spooky.js
+++ b/lib/spooky.js
@@ -6,7 +6,8 @@ var program = require('commander'),
   cloudinary = require('cloudinary'),
   fs = require('graceful-fs'),
   replace = require('replace'),
-  config = require('../config');
+  config = require('../config'),
+  glob = require('glob');
 
 exports.blogstats = function() {
 
@@ -285,18 +286,69 @@ exports.check404s = function() {
 
 }
 
-exports.waybackit = function(file) {
+exports.checkcloud = function() {
 
+    listAllPosts().then(function(files) {
+        files.forEach(function(file) {
+            findImageInFile(file).then(function(urlsFound) {
+                console.log(file +": " + urlsFound.length);
+            });
+        });    
+    });
+
+    function listAllPosts() {
+      var deferred = Q.defer();
+      glob(config.pagesDir + '/*', function(err, files) {
+          deferred.resolve(files);
+      });
+      return deferred.promise
+    }
+
+    function findImageInFile(file) {
+      var deferred = Q.defer();
+      fs.readFile(file, function (err,data) {
+        var targetUrl = '(/content/images/';
+        if (err) { if (err) deferred.reject(err); }
+        if (!err) {
+          var md = data.toString();
+          var globalStart = 0;
+          var finished = false;
+          var occurrences = [];
+          while (!finished) {
+            if (md.indexOf(targetUrl, globalStart) != -1) {
+              var start = md.indexOf(targetUrl, globalStart);
+              // find the closing "
+              var end = md.indexOf(')', start);
+              occurrences.push(md.substring(start+1, end));
+              globalStart = end;
+            } else {
+              finished = true;
+            } 
+
+          }
+          if (occurrences.length > 0) {
+              deferred.resolve(occurrences);
+          } else {
+              deferred.reject('No images found in ' + file);
+          }
+        }
+      });
+      return deferred.promise
+  }         
+}
+
+exports.cloudit = function(file) {
   findImageInFile([config.pagesDir, file].join("/"))
-    .then(function(originalUrl) {
-      findImageInWayback(originalUrl)
-      .then(uploadToCloudinary)
-      .then(function(cloudinaryUrl) {
-        replaceTextInFiles(originalUrl, cloudinaryUrl)
-      })
-      .fail(function (error) {
-        console.log(error);
-      });    
+    .then(function(originalUrls) {
+      originalUrls.forEach(function(originalUrl) {
+          uploadToCloudinary(config.blog_domain + '/' + originalUrl)
+          .then(function(cloudinaryUrl) {
+              replaceTextInFiles(originalUrl, cloudinaryUrl)
+          })
+          .fail(function (error) {
+            console.log(error);
+          });    
+        })
     })
     .fail(function (error) {
       console.log(error);
@@ -305,42 +357,35 @@ exports.waybackit = function(file) {
   function findImageInFile(file) {
       var deferred = Q.defer();
       fs.readFile(file, function (err,data) {
-        var targetUrl = 'http://blog.jeffdouglas.com/wp-content/uploads/';
+        var targetUrl = '(/content/images/';
         if (err) { if (err) deferred.reject(err); }
         if (!err) {
           var md = data.toString();
-          if (md.search(targetUrl) != -1) {
-            var start = md.indexOf(targetUrl);
-            // find the closing "
-            var end = md.indexOf('"', start);
-            deferred.resolve(md.substring(start, end));
+          var globalStart = 0;
+          var finished = false;
+          var occurrences = [];
+          while (!finished) {
+            if (md.indexOf(targetUrl, globalStart) != -1) {
+              var start = md.indexOf(targetUrl, globalStart);
+              // find the closing "
+              var end = md.indexOf(')', start);
+              occurrences.push(md.substring(start+1, end));
+              globalStart = end;
+            } else {
+              finished = true;
+            } 
+
+          }
+          if (occurrences.length > 0) {
+              deferred.resolve(occurrences);
           } else {
-            deferred.reject('No images found in ' + file);
+              deferred.reject('No images found in ' + file);
           }
         }
       });
       return deferred.promise
-  }         
+  }                  
 
-  function findImageInWayback(url) {
-      console.log('Looking in wayback for: ' + url);
-      var deferred = Q.defer();
-      var archiveUrl = "http://archive.org/wayback/available?url=";
-      request(archiveUrl + url, function (error, response, body) {
-        if (!error && response.statusCode == 200) {
-          var result = JSON.parse(body);
-          if (_.isEmpty(result.archived_snapshots)) {
-            deferred.reject("Not found in archive");
-          } else {
-            console.log("Wayback URL: " + result.archived_snapshots.closest.url);
-            deferred.resolve(result.archived_snapshots.closest.url) ;
-          }
-        } else {
-          deferred.resolve(response.statusCode);
-        }
-      })   
-      return deferred.promise
-  }
 
   function replaceTextInFiles(target, replacement) {
     console.log("Replacing...");
@@ -364,3 +409,4 @@ exports.waybackit = function(file) {
   } 
 
 }
+    

--- a/lib/spooky.js
+++ b/lib/spooky.js
@@ -14,6 +14,7 @@ exports.blogstats = function() {
     if (err) { return console.log(err); }
     if (!err) {
       var results = JSON.parse(data);
+      results = results.db[0];
       var permalinks = _.find(results.data.settings, function(s) { return s.key === 'permalinks'; });   
       var theme = _.find(results.data.settings, function(s) { return s.key === 'activeTheme'; });       
       var tags = _.map(results.data.tags, function(item) { return item.name; });   
@@ -39,6 +40,7 @@ exports.poststats = function(id) {
     if (err) { return console.log(err); }
     if (!err) {
       var results = JSON.parse(data);
+      results = results.db[0];
       var post = _.find(results.data.posts, function(p) { return p.id === id; });   
 
       post.author = _.find(results.data.users, function(u) { return u.id === post.author_id; }).name;
@@ -116,6 +118,7 @@ exports.findtag = function(tag) {
     if (err) { return console.log(err); }
     if (!err) {
       var results = JSON.parse(data);
+      results = results.db[0];
       // find the id of the tag
       var t = _.find(results.data.tags, function(s) { 
         return s.name.toLowerCase() === tag.toLowerCase(); 
@@ -185,6 +188,7 @@ exports.dump = function() {
       if (err) { return console.log(err); }
       if (!err) {
         var results = JSON.parse(data);
+        results = results.db[0];
         var contents = '';
         console.log("Saving the following pages to " + config.pagesDir + ":")
         _(results.data.posts).reverse().forEach(function(item) {
@@ -206,6 +210,7 @@ exports.toc = function() {
     if (!err) {
 
       var results = JSON.parse(data);
+      results = results.db[0];
       // determine if they are using dates in permelinks
       var permalinks = _.find(results.data.settings, function(s) { return s.key === 'permalinks'; });
       var contents = '';
@@ -241,6 +246,7 @@ exports.check404s = function() {
     if (err) { return console.log(err); }
     if (!err) {
       var results = JSON.parse(data);
+      results = results.db[0];
       var permalinks = _.find(results.data.settings, function(s) { return s.key === 'permalinks'; });
       _(results.data.posts).reverse().forEach(function(item) {
         var day = moment(item.published_at).format('DD');
@@ -265,7 +271,7 @@ exports.check404s = function() {
           console.log("404!! ****** " + resp + " ******");
         else
           console.log(resp);
-      });
+      });results = results.db[0];
     }
   };  
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "author": "Jeff Douglas <jeff@jeffdouglas.com> (http://blog.jeffdouglas.com)",  
+  "author": "Marco Mornati <marco@mornati.net> - Forked from Jeff Douglas <jeff@jeffdouglas.com> (http://blog.jeffdouglas.com)",  
   "name": "ghost-cli",
   "description": "A cli for ghost in node",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "private": false,
   "dependencies": {
     "commander": "~2.1.0",
@@ -12,6 +12,7 @@
     "graceful-fs": "~2.0.3",
     "cloudinary": "~1.0.9",
     "request": "~2.36.0",
-    "replace": "~0.2.9"
+    "replace": "~0.2.9",
+    "glob": "~4.0.6"
   }
 }


### PR DESCRIPTION
It seems the Json data stracture changed with with the new version of ghost:

{"db":[{"meta":{"exported_on":1413042678204,"version":"003"},"data":{" ....

It is a quick and dirty fix.
Maybe would be better to add a try/catch to be compatible with all ghost versions.
